### PR TITLE
Fixed summary invalid URL slashes on Windows.

### DIFF
--- a/lib/html2md.js
+++ b/lib/html2md.js
@@ -26,8 +26,7 @@ function Html2md(options) {
 private = {
   outputFileOptions: function(options) {
     var outputfile = path.parse(options.file);
-
-      options['target'] = [outputfile.dir, outputfile.name + ".md"].join('/');
+    options['target'] = [outputfile.dir, outputfile.name + ".md"].join('/');
   },
 
   outputRemoteOptions: function(options) {
@@ -35,7 +34,7 @@ private = {
 
     if (options.target) {
       var outputfile = path.parse(options.target);
-	options['targetHtml'] = [outputfile.dir, outputfile.name + ".html"].join('/');
+      options['targetHtml'] = [outputfile.dir, outputfile.name + ".html"].join('/');
     } else {
       var outputfileName = url.parse(remoteUrl).pathname.split('/').pop();
       // console.log(outputfileName);

--- a/lib/html2md.js
+++ b/lib/html2md.js
@@ -27,7 +27,7 @@ private = {
   outputFileOptions: function(options) {
     var outputfile = path.parse(options.file);
 
-    options['target'] = path.join(outputfile.dir, outputfile.name + ".md");
+      options['target'] = [outputfile.dir, outputfile.name + ".md"].join('/');
   },
 
   outputRemoteOptions: function(options) {
@@ -35,7 +35,7 @@ private = {
 
     if (options.target) {
       var outputfile = path.parse(options.target);
-      options['targetHtml'] = path.join(outputfile.dir, outputfile.name + ".html");
+	options['targetHtml'] = [outputfile.dir, outputfile.name + ".html"].join('/');
     } else {
       var outputfileName = url.parse(remoteUrl).pathname.split('/').pop();
       // console.log(outputfileName);


### PR DESCRIPTION
On Windows systems `gitbook-summary` generate invalid slashes - `\`. On GitHub it must be `/`.