### PR TITLE
[!] fix title repeat if filename is same as folder name

### DIFF
--- a/lib/summary/index.js
+++ b/lib/summary/index.js
@@ -93,7 +93,7 @@ function Summary(options) {
                     }
 
                     // The file is `readme.md`
-                    if (_.isString(n['readme']) || _.isString(n['Readme']) || _.isString(n['README'])) {
+                    else if (_.isString(n['readme']) || _.isString(n['Readme']) || _.isString(n['README'])) {
                         var readmeDir = n['readme'] || n['Readme'] || n['README'];
                         desc += _.repeat(' ', step) + formatCatalog(key, '-') + readmeDir;
                     } else {


### PR DESCRIPTION
当文件名与文件夹名相同时，也自动链接到它所在的目录上（等同与 readme.md）。
这样改的目的：
1. 修复了之前文件夹名称重复问题
2. 避免在文件夹搜索功能时，搜索到很多 readme.md 文件，文件名更有意义

- 修复前
![修复前](https://cloud.githubusercontent.com/assets/13171903/23050162/93ee921c-f4fb-11e6-9023-b04128ddd61e.png)
- 修复后
![修复后](https://cloud.githubusercontent.com/assets/13171903/23050182/a8b2ebbc-f4fb-11e6-8354-52d332b802da.png)
