### PR TITLE
non ascii title not formatting

### DIFF
--- a/bin/summary.js
+++ b/bin/summary.js
@@ -5,7 +5,7 @@ var program = require("commander");
 var color = require('bash-color');
 
 var pkg = require("../package.json");
-var summary = require("../lib/summary");
+var summary = require("../lib/summary").summary;
 var convert = require("../lib/convert");
 var html2md = require("../lib/html2md");
 

--- a/lib/summary/index.js
+++ b/lib/summary/index.js
@@ -169,7 +169,8 @@ function prettyCatalogName(fileName) {
         }
     }
     // Don`t format the files like `req.options.*` using dot, unchanged or Chinese string.
-    if (_.size(fileName.split(".")) > 1 || _.includes(unchanged, fileName) || isChinese(fileName) || disableTitleFormatting) {
+    if (_.size(fileName.split(".")) > 1 || _.includes(unchanged, fileName) || isChinese(fileName) ||
+      disableTitleFormatting || isNonAscii(fileName)) {
         return fileName;
     }
     return _.startCase(fileName);
@@ -184,6 +185,12 @@ function isChinese(string) {
     }
 }
 
+function isNonAscii(string) {
+  var regExp = /^[ -~\t\n\r]+$/gi;
+
+  return !regExp.test(string);
+}
+
 function isSkiped(key, skip) {
     var result = !_.isEmpty(skip) && _.isEqual(key.toLowerCase(), skip.toLowerCase()) || _.isEqual(key.toLowerCase(), 'readme');
     return result;
@@ -193,7 +200,10 @@ function isSkiped(key, skip) {
 function writeFile(fileName, data) {
     fs.writeFile(fileName, data, 'utf-8', function() {
         console.log(color.green("Finished, generated '"+fileName+"' successfully."));
-    })
+    });
 }
 
-module.exports = Summary;
+module.exports = {
+  summary: Summary,
+  isNonAscii: isNonAscii
+};

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2,7 +2,8 @@ var path = require('path');
 var fs = require('fs-extra');
 var should = require('should');
 
-var summary = require('../lib/summary');
+var summary = require('../lib/summary').summary;
+var isNonAscii = require('../lib/summary').isNonAscii;
 var config = require('../lib/bookJson');
 
 describe('summary/index.js', function() {
@@ -123,5 +124,10 @@ describe('summary/index.js', function() {
                 });
             });
         });
+    });
+
+    it('test non-ascii', function() {
+      should(isNonAscii('111Ab')).be.false();
+      should(isNonAscii('111Abㅁ')).be.true();
     });
 });


### PR DESCRIPTION
I'm korean, so I usually use non ascii code in my gitbook title(front-matter, not filename)
so I use gitbook-summary, result looks like below
```
- Java
  * [](/java/interface.md)
```
so I set "disableTitleFormatting": true, then result looks like below
```
- java
  * [](/java/interface.md)
```

directroy not formatting... so I add this feature!
it works like below
```
- Java
  * [인터페이스](/java/interface.md)
```