### PR TITLE
Directory names with whitespaces are supported

### DIFF
--- a/lib/summary/index.js
+++ b/lib/summary/index.js
@@ -97,7 +97,7 @@ function Summary(options) {
                     // The file is `readme.md`
                     else if (_.isString(n['readme']) || _.isString(n['Readme']) || _.isString(n['README'])) {
                         var readmeDir = n['readme'] || n['Readme'] || n['README'];
-                        desc += _.repeat(' ', step) + formatCatalog(key, '-') + readmeDir;
+                        desc += _.repeat(' ', step) + formatCatalog(key, '-') + readmeDir.replace(" ", "%20");
                     } else {
                         desc += _.repeat(' ', step) + "- " + prettyCatalogName(key) + "\n";
                     }
@@ -112,7 +112,7 @@ function Summary(options) {
                         return;
                     }
 
-                    desc += _.repeat(' ', step) + formatCatalog(key) + n;
+                    desc += _.repeat(' ', step) + formatCatalog(key) + n.replace(" ", "%20");
                 }
             }
         });


### PR DESCRIPTION
Fix for #37 

Replacing the whitespaces in directory names with the URL-encoded whitespace.