### PR TITLE
Fix replace multiple spaces in a directory name

### DIFF
--- a/lib/summary/index.js
+++ b/lib/summary/index.js
@@ -97,7 +97,7 @@ function Summary(options) {
                     // The file is `readme.md`
                     else if (_.isString(n['readme']) || _.isString(n['Readme']) || _.isString(n['README'])) {
                         var readmeDir = n['readme'] || n['Readme'] || n['README'];
-                        desc += _.repeat(' ', step) + formatCatalog(key, '-') + readmeDir.replace(" ", "%20");
+                        desc += _.repeat(' ', step) + formatCatalog(key, '-') + readmeDir.replace(/ /g, "%20");
                     } else {
                         desc += _.repeat(' ', step) + "- " + prettyCatalogName(key) + "\n";
                     }
@@ -112,7 +112,7 @@ function Summary(options) {
                         return;
                     }
 
-                    desc += _.repeat(' ', step) + formatCatalog(key) + n.replace(" ", "%20");
+                    desc += _.repeat(' ', step) + formatCatalog(key) + n.replace(/ /g, "%20");
                 }
             }
         });


### PR DESCRIPTION
Hey everyone,

This PR fixes a case when a directory name contains few spaces. Current behaviour replaces only the first space in a name.